### PR TITLE
Add Material-UI theme and convert to light mode styling

### DIFF
--- a/main-project/src/App.tsx
+++ b/main-project/src/App.tsx
@@ -1,8 +1,30 @@
-import React from 'react';
-import { useAuthStore } from './store/authStore';
-import LoginPage from './modules/LoginPage/LoginPage';
+import React from "react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { CssBaseline } from "@mui/material";
+import { useAuthStore } from "./store/authStore";
+import LoginPage from "./modules/LoginPage/LoginPage";
 // Swap with your real main page once built:
-import Profile from './modules/Profile/Profile';
+import Profile from "./modules/Profile/Profile";
+
+const lightTheme = createTheme({
+  palette: {
+    mode: "light",
+    primary: {
+      main: "#0066cc",
+    },
+    secondary: {
+      main: "#6c757d",
+    },
+    background: {
+      default: "#f8f9fa",
+      paper: "#ffffff",
+    },
+    text: {
+      primary: "#213547",
+      secondary: "#495057",
+    },
+  },
+});
 
 const App: React.FC = () => {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);

--- a/main-project/src/App.tsx
+++ b/main-project/src/App.tsx
@@ -29,7 +29,12 @@ const lightTheme = createTheme({
 const App: React.FC = () => {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
-  return isLoggedIn ? <Profile /> : <LoginPage />;
+  return (
+    <ThemeProvider theme={lightTheme}>
+      <CssBaseline />
+      {isLoggedIn ? <Profile /> : <LoginPage />}
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/main-project/src/index.css
+++ b/main-project/src/index.css
@@ -3,8 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
+  color-scheme: light;
+  color: #213547;
   background-color: #ffffff;
 
   font-synthesis: none;
@@ -28,41 +28,34 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #f8f9fa;
 }
 
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  color: #213547;
 }
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid #e0e0e0;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #ffffff;
+  color: #213547;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition:
+    border-color 0.25s,
+    background-color 0.25s;
 }
 button:hover {
   border-color: #646cff;
+  background-color: #f5f5f5;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/main-project/src/main.jsx
+++ b/main-project/src/main.jsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import App from './App.tsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/main-project/src/main.jsx
+++ b/main-project/src/main.jsx
@@ -1,17 +1,10 @@
-<<<<<<< HEAD
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
-=======
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App.tsx';
->>>>>>> origin/main
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 );

--- a/main-project/src/modules/LoginPage/LoginPage.tsx
+++ b/main-project/src/modules/LoginPage/LoginPage.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 // Adjust import path to your users.json location:
-import users from '../../data/users.json';
-import { useAuthStore } from '../../store/authStore';
-import { TextField, Button, Box } from '@mui/material';
+import users from "../../data/users.json";
+import { useAuthStore } from "../../store/authStore";
+import { TextField, Button, Box } from "@mui/material";
 
 const LoginPage: React.FC = () => {
   const login = useAuthStore((state) => state.login);
-  const [username, setUsername] = useState('');
-  const [error, setError] = useState('');
+  const [username, setUsername] = useState("");
+  const [error, setError] = useState("");
 
   const handleLogin = () => {
     const foundAny = users.find((u) => u.username === username);
@@ -15,35 +15,35 @@ const LoginPage: React.FC = () => {
       // Ensure we have exactly 3 preferences, filling with empty strings if missing
       const { preferenze, ...rest } = foundAny;
       const tuplePrefs: [string, string, string] = [
-        preferenze[0] || '',
-        preferenze[1] || '',
-        preferenze[2] || '',
+        preferenze[0] || "",
+        preferenze[1] || "",
+        preferenze[2] || "",
       ];
       login({ ...rest, preferenze: tuplePrefs });
     } else {
-      setError('Utente non trovato');
+      setError("Utente non trovato");
     }
   };
 
   return (
     <Box
       sx={{
-        width: '100vw',
-        margin: '80px auto',
-        display: 'flex',
-        flexDirection: 'column',
+        width: "100vw",
+        margin: "80px auto",
+        display: "flex",
+        flexDirection: "column",
         gap: 2,
-        color: 'white',
+        color: "#213547",
       }}
     >
       <TextField
-        label='Username'
+        label="Username"
         value={username}
         onChange={(e) => setUsername(e.target.value)}
         autoFocus
       />
-      {error && <Box sx={{ color: 'red' }}>{error}</Box>}
-      <Button variant='contained' onClick={handleLogin}>
+      {error && <Box sx={{ color: "red" }}>{error}</Box>}
+      <Button variant="contained" onClick={handleLogin}>
         Login
       </Button>
     </Box>

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -65,6 +65,8 @@ const Profile: React.FC = () => {
           alignItems: "center",
           gap: "19px",
           flexShrink: 0,
+          boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)",
+          border: "1px solid #e0e0e0",
         }}
       >
         {/* Profile Image */}

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -208,7 +208,7 @@ const Profile: React.FC = () => {
               multiline
               fullWidth
               minRows={3}
-              sx={{ mb: 2, bgcolor: "#222", color: "#FFF" }}
+              sx={{ mb: 2, bgcolor: "#ffffff", color: "#213547" }}
             />
           </Box>
         ) : (

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -274,7 +274,7 @@ const Profile: React.FC = () => {
             }}
             labelProps={{
               sx: {
-                color: "#BCBEC5",
+                color: "#495057",
                 fontFamily:
                   "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
                 fontSize: { xs: "20px", md: "26px" },

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -218,7 +218,7 @@ const Profile: React.FC = () => {
             sx={{
               width: { xs: "100%", md: "570px" },
               height: { xs: "auto", md: "236px" },
-              background: "#343A43",
+              background: "#ffffff",
               borderRadius: "8px",
               padding: "18px 22px",
               "& .MuiTypography-h5": {

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -228,7 +228,7 @@ const Profile: React.FC = () => {
                 fontSize: "24px",
                 fontWeight: 500,
                 lineHeight: "normal",
-                borderBottom: "2px solid #E00C0C",
+                borderBottom: "2px solid #0066cc",
                 marginBottom: "54px",
                 paddingBottom: "4px",
                 display: "inline-block",

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -260,7 +260,7 @@ const Profile: React.FC = () => {
                   cp[i] = e.target.value;
                   setPrefs(cp);
                 }}
-                sx={{ mb: 1, bgcolor: "#222", color: "#FFF", width: 240 }}
+                sx={{ mb: 1, bgcolor: "#ffffff", color: "#213547", width: 240 }}
               />
             ))}
           </Box>

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -93,7 +93,7 @@ const Profile: React.FC = () => {
             sx={{
               textAlign: "left",
               "& .MuiTypography-h3": {
-                color: "#BCBEC5",
+                color: "#495057",
                 fontFamily:
                   "Hexagon Akkurat, -apple-system, Roboto, Helvetica, sans-serif",
                 fontSize: { xs: "32px", md: "41px" },

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -187,7 +187,7 @@ const Profile: React.FC = () => {
         {/* Profile Header */}
         <Box
           sx={{
-            color: "#BCBEC5",
+            color: "#495057",
             fontFamily: "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
             fontSize: { xs: "24px", md: "32px" },
             fontWeight: 500,

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -294,7 +294,7 @@ const Profile: React.FC = () => {
                   paddingBottom: "9px",
                 },
                 "& .MuiTypography-h5": {
-                  color: "#BCBEC5",
+                  color: "#495057",
                   fontFamily:
                     "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
                   fontSize: { xs: "18px", md: "24px" },

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -223,6 +223,8 @@ const Profile: React.FC = () => {
               background: "#ffffff",
               borderRadius: "8px",
               padding: "18px 22px",
+              boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)",
+              border: "1px solid #e0e0e0",
               "& .MuiTypography-h5": {
                 color: "#213547",
                 fontFamily:

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -235,7 +235,7 @@ const Profile: React.FC = () => {
                 width: "auto",
               },
               "& .MuiTypography-body1": {
-                color: "#BCBEC5",
+                color: "#495057",
                 fontFamily:
                   "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
                 fontSize: "20px",

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -1,25 +1,25 @@
-import React, { useState } from 'react';
-import { Box, TextField, Button } from '@mui/material';
+import React, { useState } from "react";
+import { Box, TextField, Button } from "@mui/material";
 import {
   UserInfo,
   CustomButton,
   ImageBox,
   PreferencesList,
   BioCard,
-} from '../../components';
-import { useAuthStore } from '../../store/authStore';
+} from "../../components";
+import { useAuthStore } from "../../store/authStore";
 const Profile: React.FC = () => {
   const { user, logout, setBioAndPreferenze } = useAuthStore();
   const [editing, setEditing] = useState(false);
 
-  const [bio, setBio] = useState(user?.bio || '');
+  const [bio, setBio] = useState(user?.bio || "");
   const [prefs, setPrefs] = useState<[string, string, string]>(
-    user?.preferenze || ['', '', '']
+    user?.preferenze || ["", "", ""],
   );
   // Start editing: snapshot current user values
   const startEdit = () => {
-    setBio(user?.bio || '');
-    setPrefs(user?.preferenze || ['', '', '']);
+    setBio(user?.bio || "");
+    setPrefs(user?.preferenze || ["", "", ""]);
     setEditing(true);
   };
   // Save: apply to store
@@ -34,36 +34,36 @@ const Profile: React.FC = () => {
   return (
     <Box
       sx={{
-        width: '100vw',
-        height: '100vh',
-        background: '#303030',
-        display: 'flex',
-        gap: '135px',
-        padding: { xs: '20px', md: '102px' },
-        boxSizing: 'border-box',
-        overflow: 'hidden',
-        '@media (max-width: 768px)': {
-          flexDirection: 'column',
-          gap: '20px',
-          padding: '20px',
-          height: 'auto',
-          overflowY: 'auto',
+        width: "100vw",
+        height: "100vh",
+        background: "#f8f9fa",
+        display: "flex",
+        gap: "135px",
+        padding: { xs: "20px", md: "102px" },
+        boxSizing: "border-box",
+        overflow: "hidden",
+        "@media (max-width: 768px)": {
+          flexDirection: "column",
+          gap: "20px",
+          padding: "20px",
+          height: "auto",
+          overflowY: "auto",
         },
       }}
     >
       {/* Left Sidebar */}
       <Box
         sx={{
-          width: { xs: '100%', md: '439px' },
-          height: { xs: 'auto', md: '582px' },
-          background: '#343A43',
-          borderRadius: '8px',
-          padding: '46px',
-          boxSizing: 'border-box',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '19px',
+          width: { xs: "100%", md: "439px" },
+          height: { xs: "auto", md: "582px" },
+          background: "#343A43",
+          borderRadius: "8px",
+          padding: "46px",
+          boxSizing: "border-box",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "19px",
           flexShrink: 0,
         }}
       >
@@ -71,45 +71,45 @@ const Profile: React.FC = () => {
         <ImageBox
           src={user.photo}
           alt={`${user.nome} ${user.cognome}`}
-          maxWidth='250px'
-          borderRadius='30px'
+          maxWidth="250px"
+          borderRadius="30px"
           sx={{
-            width: '250px',
-            height: '276px',
-            background: '#D9E9BE',
+            width: "250px",
+            height: "276px",
+            background: "#D9E9BE",
             flexShrink: 0,
-            '@media (max-width: 768px)': {
-              width: '200px',
-              height: '220px',
+            "@media (max-width: 768px)": {
+              width: "200px",
+              height: "220px",
             },
           }}
         />
 
         {/* User Information */}
-        <Box sx={{ width: '100%', marginTop: '19px' }}>
+        <Box sx={{ width: "100%", marginTop: "19px" }}>
           <UserInfo
             name={`${user.nome} ${user.cognome}`}
             birthDate={user.dataNascita}
             sx={{
-              textAlign: 'left',
-              '& .MuiTypography-h3': {
-                color: '#BCBEC5',
+              textAlign: "left",
+              "& .MuiTypography-h3": {
+                color: "#BCBEC5",
                 fontFamily:
-                  'Hexagon Akkurat, -apple-system, Roboto, Helvetica, sans-serif',
-                fontSize: { xs: '32px', md: '41px' },
+                  "Hexagon Akkurat, -apple-system, Roboto, Helvetica, sans-serif",
+                fontSize: { xs: "32px", md: "41px" },
                 fontWeight: 400,
-                lineHeight: '47px',
-                letterSpacing: '0px',
-                marginBottom: '19px',
+                lineHeight: "47px",
+                letterSpacing: "0px",
+                marginBottom: "19px",
               },
-              '& .MuiTypography-h5': {
-                color: '#BCBEC5',
+              "& .MuiTypography-h5": {
+                color: "#BCBEC5",
                 fontFamily:
-                  'Hexagon Akkurat, -apple-system, Roboto, Helvetica, sans-serif',
-                fontSize: { xs: '20px', md: '26px' },
+                  "Hexagon Akkurat, -apple-system, Roboto, Helvetica, sans-serif",
+                fontSize: { xs: "20px", md: "26px" },
                 fontWeight: 400,
-                lineHeight: '38px',
-                letterSpacing: '0px',
+                lineHeight: "38px",
+                letterSpacing: "0px",
               },
             }}
           />
@@ -118,56 +118,56 @@ const Profile: React.FC = () => {
         {/* Buttons */}
         <Box
           sx={{
-            marginTop: 'auto',
-            alignSelf: 'flex-start',
-            display: 'flex',
-            gap: '12px',
+            marginTop: "auto",
+            alignSelf: "flex-start",
+            display: "flex",
+            gap: "12px",
           }}
         >
           <CustomButton
-            label='Logout'
-            variant='outlined'
-            size='medium'
-            color='warning'
+            label="Logout"
+            variant="outlined"
+            size="medium"
+            color="warning"
             onClick={logout}
             sx={{
-              borderRadius: '8px',
-              fontSize: '16px',
+              borderRadius: "8px",
+              fontSize: "16px",
               fontFamily:
-                'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
+                "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
               fontWeight: 400,
-              textTransform: 'none',
+              textTransform: "none",
             }}
           />
 
           <CustomButton
-            label={editing ? 'Salva' : 'Modifica'}
-            variant='outlined'
-            size='medium'
-            color='info'
+            label={editing ? "Salva" : "Modifica"}
+            variant="outlined"
+            size="medium"
+            color="info"
             onClick={editing ? save : startEdit}
             sx={{
-              borderRadius: '8px',
-              fontSize: '16px',
+              borderRadius: "8px",
+              fontSize: "16px",
               fontFamily:
-                'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
+                "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
               fontWeight: 400,
-              textTransform: 'none',
+              textTransform: "none",
             }}
           />
           {editing && (
             <CustomButton
-              label='Annulla'
-              size='medium'
+              label="Annulla"
+              size="medium"
               onClick={cancel}
-              color='inherit'
+              color="inherit"
               sx={{
-                borderRadius: '8px',
-                fontSize: '16px',
+                borderRadius: "8px",
+                fontSize: "16px",
                 fontFamily:
-                  'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
+                  "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
                 fontWeight: 400,
-                textTransform: 'none',
+                textTransform: "none",
               }}
             />
           )}
@@ -178,21 +178,21 @@ const Profile: React.FC = () => {
       <Box
         sx={{
           flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '24px',
-          position: 'relative',
+          display: "flex",
+          flexDirection: "column",
+          gap: "24px",
+          position: "relative",
         }}
       >
         {/* Profile Header */}
         <Box
           sx={{
-            color: '#BCBEC5',
-            fontFamily: 'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
-            fontSize: { xs: '24px', md: '32px' },
+            color: "#BCBEC5",
+            fontFamily: "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+            fontSize: { xs: "24px", md: "32px" },
             fontWeight: 500,
-            lineHeight: 'normal',
-            marginBottom: '39px',
+            lineHeight: "normal",
+            marginBottom: "39px",
           }}
         >
           Profilo
@@ -202,46 +202,46 @@ const Profile: React.FC = () => {
         {editing ? (
           <Box>
             <TextField
-              label='Bio'
+              label="Bio"
               value={bio}
               onChange={(e) => setBio(e.target.value)}
               multiline
               fullWidth
               minRows={3}
-              sx={{ mb: 2, bgcolor: '#222', color: '#FFF' }}
+              sx={{ mb: 2, bgcolor: "#222", color: "#FFF" }}
             />
           </Box>
         ) : (
           <BioCard
-            label='Bio'
+            label="Bio"
             text={user.bio}
             sx={{
-              width: { xs: '100%', md: '570px' },
-              height: { xs: 'auto', md: '236px' },
-              background: '#343A43',
-              borderRadius: '8px',
-              padding: '18px 22px',
-              '& .MuiTypography-h5': {
-                color: '#FFF',
+              width: { xs: "100%", md: "570px" },
+              height: { xs: "auto", md: "236px" },
+              background: "#343A43",
+              borderRadius: "8px",
+              padding: "18px 22px",
+              "& .MuiTypography-h5": {
+                color: "#FFF",
                 fontFamily:
-                  'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
-                fontSize: '24px',
+                  "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+                fontSize: "24px",
                 fontWeight: 500,
-                lineHeight: 'normal',
-                borderBottom: '2px solid #E00C0C',
-                marginBottom: '54px',
-                paddingBottom: '4px',
-                display: 'inline-block',
-                width: 'auto',
+                lineHeight: "normal",
+                borderBottom: "2px solid #E00C0C",
+                marginBottom: "54px",
+                paddingBottom: "4px",
+                display: "inline-block",
+                width: "auto",
               },
-              '& .MuiTypography-body1': {
-                color: '#BCBEC5',
+              "& .MuiTypography-body1": {
+                color: "#BCBEC5",
                 fontFamily:
-                  'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
-                fontSize: '20px',
+                  "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+                fontSize: "20px",
                 fontWeight: 500,
-                lineHeight: 'normal',
-                marginTop: '0',
+                lineHeight: "normal",
+                marginTop: "0",
               },
             }}
           />
@@ -254,52 +254,52 @@ const Profile: React.FC = () => {
               <TextField
                 key={i}
                 label={`Preferenza ${i + 1}`}
-                value={prefs[i] || ''}
+                value={prefs[i] || ""}
                 onChange={(e) => {
                   const cp = [...prefs] as [string, string, string];
                   cp[i] = e.target.value;
                   setPrefs(cp);
                 }}
-                sx={{ mb: 1, bgcolor: '#222', color: '#FFF', width: 240 }}
+                sx={{ mb: 1, bgcolor: "#222", color: "#FFF", width: 240 }}
               />
             ))}
           </Box>
         ) : (
           <PreferencesList
-            label='Preferenze'
+            label="Preferenze"
             preferences={user.preferenze}
             sx={{
-              width: { xs: '100%', md: '167px' },
-              height: '166px',
+              width: { xs: "100%", md: "167px" },
+              height: "166px",
             }}
             labelProps={{
               sx: {
-                color: '#BCBEC5',
+                color: "#BCBEC5",
                 fontFamily:
-                  'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
-                fontSize: { xs: '20px', md: '26px' },
+                  "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+                fontSize: { xs: "20px", md: "26px" },
                 fontWeight: 500,
-                lineHeight: 'normal',
-                marginBottom: '34px',
+                lineHeight: "normal",
+                marginBottom: "34px",
               },
             }}
             listProps={{
               sx: {
-                listStyleType: 'disc',
-                paddingLeft: '20px',
-                '& .MuiListItem-root': {
-                  display: 'list-item',
+                listStyleType: "disc",
+                paddingLeft: "20px",
+                "& .MuiListItem-root": {
+                  display: "list-item",
                   paddingLeft: 0,
                   paddingTop: 0,
-                  paddingBottom: '9px',
+                  paddingBottom: "9px",
                 },
-                '& .MuiTypography-h5': {
-                  color: '#BCBEC5',
+                "& .MuiTypography-h5": {
+                  color: "#BCBEC5",
                   fontFamily:
-                    'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
-                  fontSize: { xs: '18px', md: '24px' },
+                    "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
+                  fontSize: { xs: "18px", md: "24px" },
                   fontWeight: 300,
-                  lineHeight: 'normal',
+                  lineHeight: "normal",
                 },
               },
             }}

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -56,7 +56,7 @@ const Profile: React.FC = () => {
         sx={{
           width: { xs: "100%", md: "439px" },
           height: { xs: "auto", md: "582px" },
-          background: "#343A43",
+          background: "#ffffff",
           borderRadius: "8px",
           padding: "46px",
           boxSizing: "border-box",

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -103,7 +103,7 @@ const Profile: React.FC = () => {
                 marginBottom: "19px",
               },
               "& .MuiTypography-h5": {
-                color: "#BCBEC5",
+                color: "#495057",
                 fontFamily:
                   "Hexagon Akkurat, -apple-system, Roboto, Helvetica, sans-serif",
                 fontSize: { xs: "20px", md: "26px" },

--- a/main-project/src/modules/Profile/Profile.tsx
+++ b/main-project/src/modules/Profile/Profile.tsx
@@ -222,7 +222,7 @@ const Profile: React.FC = () => {
               borderRadius: "8px",
               padding: "18px 22px",
               "& .MuiTypography-h5": {
-                color: "#FFF",
+                color: "#213547",
                 fontFamily:
                   "Roboto, -apple-system, Roboto, Helvetica, sans-serif",
                 fontSize: "24px",


### PR DESCRIPTION
This pull request adds Material-UI theming support and converts the application from dark mode to light mode styling.

Changes made:
- Added ThemeProvider and createTheme from @mui/material/styles to App.tsx
- Created lightTheme configuration with custom color palette
- Added CssBaseline component for consistent baseline styles
- Updated CSS color scheme from "light dark" to "light" only
- Changed text colors from white/light colors to dark colors (#213547, #495057)
- Updated background colors to light theme (#f8f9fa, #ffffff)
- Modified button styling to use light theme colors with borders
- Removed dark mode media query styles from index.css
- Updated component styling throughout Profile and LoginPage to use light colors
- Added box shadows and borders to cards for better visual separation
- Changed quote style from single quotes to double quotes across all files

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/fbdb351362334ad2b9659d3d77737a92/vibe-oasis)

👀 [Preview Link](https://fbdb351362334ad2b9659d3d77737a92-vibe-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fbdb351362334ad2b9659d3d77737a92</projectId>-->
<!--<branchName>vibe-oasis</branchName>-->